### PR TITLE
Node 4+, let Travis CI use stable, 6, 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 'stable'
+  - '6'
+  - '4'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "bugs": {
     "url": "https://github.com/eugeneware/ffmpeg-static/issues"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "dependencies": {},
   "devDependencies": {
     "tape": "~2.3.2"


### PR DESCRIPTION
Because you may find this change controversial, I created a separate PR. **Note that this PR is a breaking change that, according to [SemVer](http://semver.org), requires a version bump to `3.0.0`.**

[Node `0.10` is not being maintained anymore](https://github.com/nodejs/LTS#lts-schedule1).