### PR TITLE
prevent killing the process

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,19 @@
-var os = require('os')
 var path = require('path')
+var fs = require('fs')
 
-var platform = os.platform()
-if (platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') {
-  console.error('Unsupported platform.')
-  process.exit(1)
-}
+var paths = {}
+fs.readdirSync('bin').forEach(function(platform) {
+  var platformPath = path.join('bin', platform)
+  fs.readdirSync(platformPath).forEach(function(arch) {
+    paths[platform] = paths[platform] || {}
+    paths[platform][arch] = path.join(
+      __dirname,
+      'bin',
+      platform,
+      arch,
+      platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg'
+    )
+  })
+})
 
-var arch = os.arch()
-if (platform === 'darwin' && arch !== 'x64') {
-  console.error('Unsupported architecture.')
-  process.exit(1)
-}
-
-var ffmpegPath = path.join(
-  __dirname,
-  'bin',
-  platform,
-  arch,
-  platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg'
-)
-
-exports.path = ffmpegPath;
+exports.paths = paths

--- a/index.js
+++ b/index.js
@@ -1,19 +1,24 @@
+var os = require('os')
 var path = require('path')
-var fs = require('fs')
 
-var paths = {}
-fs.readdirSync('bin').forEach(function(platform) {
-  var platformPath = path.join('bin', platform)
-  fs.readdirSync(platformPath).forEach(function(arch) {
-    paths[platform] = paths[platform] || {}
-    paths[platform][arch] = path.join(
-      __dirname,
-      'bin',
-      platform,
-      arch,
-      platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg'
-    )
-  })
-})
+var binaries = {
+  darwin: ['x64'],
+  linux: ['x64', 'ia32', 'arm64', 'arm'],
+  win32: ['x64', 'ia32']
+}
 
-exports.paths = paths
+var platform = os.platform()
+var arch = os.arch()
+var ffmpegPath = path.join(
+  __dirname,
+  'bin',
+  platform,
+  arch,
+  platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg'
+)
+
+if (!binaries[platform] || binaries[platform].indexOf(arch) === -1) {
+  ffmpegPath = null
+}
+
+exports.path = ffmpegPath

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var os = require('os')
 var path = require('path')
 
-var binaries = {
+var binaries = Object.assign(Object.create(null), {
   darwin: ['x64'],
   linux: ['x64', 'ia32', 'arm64', 'arm'],
   win32: ['x64', 'ia32']
-}
+})
 
 var platform = os.platform()
 var arch = os.arch()


### PR DESCRIPTION
let the user choose the binary instead of killing the process if none was found
i want to run the same node server on desktop and mobile with minimum changes in the application code, but because of that `process.exit(1)` call i need to do code split