### PR TITLE
relicense package as GPL, upload license & readme files to GitHub releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -37,9 +37,36 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/darwin-x64.README
+          asset_name: darwin-x64.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bin/linux-arm
           asset_name: linux-arm
           asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-arm.README
+          asset_name: linux-arm.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-arm.LICENSE
+          asset_name: linux-arm.LICENSE
+          asset_content_type: text/plain
 
       - uses: actions/upload-release-asset@v1.0.1
         env:
@@ -55,9 +82,45 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-arm64.README
+          asset_name: linux-arm64.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-arm64.LICENSE
+          asset_name: linux-arm64.LICENSE
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bin/linux-ia32
           asset_name: linux-ia32
           asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-ia32.README
+          asset_name: linux-ia32.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-ia32.LICENSE
+          asset_name: linux-ia32.LICENSE
+          asset_content_type: text/plain
 
       - uses: actions/upload-release-asset@v1.0.1
         env:
@@ -73,6 +136,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-x64.README
+          asset_name: linux-x64.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/linux-x64.LICENSE
+          asset_name: linux-x64.LICENSE
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bin/win32-ia32
           asset_name: win32-ia32
           asset_content_type: application/octet-stream
@@ -82,6 +163,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/win32-ia32.README
+          asset_name: win32-ia32.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/win32-ia32.LICENSE
+          asset_name: win32-ia32.LICENSE
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bin/win32-x64
           asset_name: win32-x64
           asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/win32-x64.README
+          asset_name: win32-x64.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/win32-x64.LICENSE
+          asset_name: win32-x64.LICENSE
+          asset_content_type: text/plain

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module is installed via npm:
 $ npm install ffmpeg-static
 ```
 
-*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b4.2.2` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.2.2).
+*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b4.2.2` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.2.2). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
 
 ## Example Usage
 
@@ -42,6 +42,8 @@ Check the [example script](example.js) for a more thorough example.
 - [Windows builds](https://ffmpeg.zeranoe.com/builds/win64/static/)
 - [Linux builds](https://johnvansickle.com/ffmpeg/)
 - [macOS builds](https://evermeet.cx/pub/ffmpeg/)
+
+The build script extracts build information and (when possible) the license file from the downloaded package or the distribution server. Please consult the individual build's project site for exact source versions, which you can locate based on the version information included in the README file.
 
 ## Show your support
 

--- a/build/index.sh
+++ b/build/index.sh
@@ -20,6 +20,8 @@ download 'https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-latest-win64-sta
 echo '  extracting'
 unzip -o -d ../bin -j win32-x64.zip '**/ffmpeg.exe'
 mv ../bin/ffmpeg.exe ../bin/win32-x64
+unzip -p win32-x64.zip '**/LICENSE.txt' > ../bin/win32-x64.LICENSE
+unzip -p win32-x64.zip '**/README.txt' > ../bin/win32-x64.README
 
 echo 'windows ia32'
 echo '  downloading from ffmpeg.zeranoe.com'
@@ -27,6 +29,8 @@ download 'https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-latest-win32-sta
 echo '  extracting'
 unzip -o -d ../bin -j win32-ia32.zip '**/ffmpeg.exe'
 mv ../bin/ffmpeg.exe ../bin/win32-ia32
+unzip -p win32-ia32.zip '**/LICENSE.txt' > ../bin/win32-ia32.LICENSE
+unzip -p win32-ia32.zip '**/README.txt' > ../bin/win32-ia32.README
 
 echo 'linux x64'
 echo '  downloading from johnvansickle.com'
@@ -34,6 +38,8 @@ download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.
 echo '  extracting'
 $tar_exec -x -C ../bin --strip-components 1 -f linux-x64.tar.xz --wildcards '*/ffmpeg'
 mv ../bin/ffmpeg ../bin/linux-x64
+$tar_exec -x -f linux-x64.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-x64.LICENSE
+$tar_exec -x -f linux-x64.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-x64.README
 
 echo 'linux ia32'
 echo '  downloading from johnvansickle.com'
@@ -41,6 +47,8 @@ download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.t
 echo '  extracting'
 $tar_exec -x -C ../bin --strip-components 1 -f linux-ia32.tar.xz --wildcards '*/ffmpeg'
 mv ../bin/ffmpeg ../bin/linux-ia32
+$tar_exec -x -f linux-ia32.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-ia32.LICENSE
+$tar_exec -x -f linux-ia32.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-ia32.README
 
 echo 'linux arm'
 echo '  downloading from johnvansickle.com'
@@ -48,6 +56,8 @@ download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-armhf-static.
 echo '  extracting'
 $tar_exec -x -C ../bin --strip-components 1 -f linux-arm.tar.xz --wildcards '*/ffmpeg'
 mv ../bin/ffmpeg ../bin/linux-arm
+$tar_exec -x -f linux-arm.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-arm.LICENSE
+$tar_exec -x -f linux-arm.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-arm.README
 
 echo 'linux arm64'
 echo '  downloading from johnvansickle.com'
@@ -55,6 +65,8 @@ download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.
 echo '  extracting'
 $tar_exec -x -C ../bin --strip-components 1 -f linux-arm64.tar.xz --wildcards '*/ffmpeg'
 mv ../bin/ffmpeg ../bin/linux-arm64
+$tar_exec -x -f linux-arm64.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-arm64.LICENSE
+$tar_exec -x -f linux-arm64.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-arm64.README
 
 echo 'darwin x64'
 echo '  downloading from evermeet.cx'
@@ -62,3 +74,4 @@ download "https://evermeet.cx/ffmpeg/getrelease" darwin-x64-ffmpeg.7z
 echo '  extracting'
 7zr e -y -bd -o../bin darwin-x64-ffmpeg.7z >/dev/null
 mv ../bin/ffmpeg ../bin/darwin-x64
+curl -I "https://evermeet.cx/ffmpeg/getrelease" | grep -i ^location: | sed -e 's;location: ;Retrieved from https://evermeet.cx/ffmpeg/;' > ../bin/darwin-x64.README

--- a/build/index.sh
+++ b/build/index.sh
@@ -11,7 +11,7 @@ set -e
 echo using tar executable at $tar_exec
 
 download () {
-	curl -L -# -A 'https://github.com/eugeneware/ffmpeg-static' -o $2 $1
+	curl -L -# --compressed -A 'https://github.com/eugeneware/ffmpeg-static' -o $2 $1
 }
 
 echo 'windows x64'
@@ -74,4 +74,5 @@ download "https://evermeet.cx/ffmpeg/getrelease" darwin-x64-ffmpeg.7z
 echo '  extracting'
 7zr e -y -bd -o../bin darwin-x64-ffmpeg.7z >/dev/null
 mv ../bin/ffmpeg ../bin/darwin-x64
-curl -I "https://evermeet.cx/ffmpeg/getrelease" | grep -i ^location: | sed -e 's;location: ;Retrieved from https://evermeet.cx/ffmpeg/;' > ../bin/darwin-x64.README
+header=$(curl -s -X HEAD -I 'https://evermeet.cx/ffmpeg/getrelease' | grep -i '^location:')
+echo "Retrieved from https://evermeet.cx/ffmpeg${header:10}" > ../bin/darwin-x64.README

--- a/install.js
+++ b/install.js
@@ -17,6 +17,9 @@ function downloadFile(url, destinationPath, progressCallback) {
   get(url, function(err, response) {
     if (err || response.statusCode !== 200) {
       const error = new Error(`Download failed. URL: ${url}`);
+      if (response) {
+        error.statusCode = response.statusCode;
+      }
       reject(err || error);
       return;
     }
@@ -68,7 +71,27 @@ if (ffmpegPath) {
   }).catch(error => {
     console.error(error);
     process.exit(1);
-  });
+  }).then(
+    downloadFile(`${getDownloadUrl()}.README`, `${ffmpegPath}.README`, () => {})
+      .catch(error => {
+        if (error.statusCode === 404) {
+          console.warn(error.message);
+        } else {
+          console.error(error);
+          process.exit(1);
+        }
+      })
+  ).then(
+    downloadFile(`${getDownloadUrl()}.LICENSE`, `${ffmpegPath}.LICENSE`, () => {})
+      .catch(error => {
+        if (error.statusCode === 404) {
+          console.warn(error.message);
+        } else {
+          console.error(error);
+          process.exit(1);
+        }
+      })
+  );
 } else {
   console.error(
     "ffmpeg-static install failed: No binary found for architecture"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "contributors": [
     "Jannis R <mail@jannisr.de>"
   ],
-  "license": "BSD-3-Clause",
+  "license": "GPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/eugeneware/ffmpeg-static/issues"
   },


### PR DESCRIPTION
Resolves #8 

This pull request accomplishes the following. The main benefit is to capture additional (incremental) information helpful in determining license requirements compared to existing versions. Of note, the license expression in `package.json` has been updated to `GPL-3.0-or-later` to reflect the resultant installed module, as compared to the source package.
  - [x] During package download in `install.sh`, extract or download a README file from the binary maintainer's archive or website. (Missing for darwin-x64, instead records the version downloaded)
  - [x] During package download in `install.sh`, extract or download a LICENSE file from the binary maintainer's archive. (Missing for darwin-x64)
  - [x] During tagging, the GitHub action will upload the README and LICENSE files to the resultant release.
  - [x] During package install, download any *.README or *.LICENSE file located within the same release for the same platform, and place next to the downloaded FFmpeg binary.
  - [x] Updates the license expression in `package.json` to `GPL-3.0-or-later` so that packages scanned after being installed can accommodate discovery of GPL-licensed binaries.
  - [ ] Update the README.md file to include notes about the location of the README file and adds a note about the binaries being under a different license than this package.
  - [ ] ~Update the `install.js` script to allow `FFMPEG_BINARY_RELEASE` to be specified as a GitHub `user/repo#tagname` format during `npm install`. For example `FFMPEG_BINARY_RELEASE=qawolf/ffmpeg-static#b3.0.0-2 npm install`.~

Additional observations and opportunities
  - [ ] Update package-lock.json version for the package upon release (i.e. 3.0.0->4.0.0)
  - [ ] Download a zip file from the OSX build maintainer's website instead of 7-zip to reduce dependencies required to build.

