### PR TITLE
Fix url

### DIFF
--- a/install.js
+++ b/install.js
@@ -2,6 +2,7 @@
 
 var fs = require("fs");
 var os = require("os");
+const {URL} = require('url');
 const {encode: encodeQuery} = require('querystring')
 const {strictEqual} = require('assert')
 const envPaths = require('env-paths')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-static",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "ffmpeg static binaries for Mac OSX and Linux and Windows",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
URL is not defined error fix for node-v8

node-v8 doc:" Note: In Web Browsers, the WHATWG URL class is a global that is always available. In Node.js, however, the URL class must be accessed via require('url').URL."

https://nodejs.org/docs/latest-v8.x/api/url.html
https://cloud.google.com/functions/docs/concepts/nodejs-8-runtime
