### PR TITLE
Use npm env-variables as source of target arch/platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ if (process.env.FFMPEG_BIN) {
     win32: ['x64', 'ia32']
   })
 
-  var platform = os.platform()
-  var arch = os.arch()
+  var platform = process.env.npm_config_platform || os.platform()
+  var arch = process.env.npm_config_arch || os.arch()
 
   var ffmpegPath = path.join(
     __dirname,

--- a/install.js
+++ b/install.js
@@ -136,7 +136,9 @@ const release = (
   process.env.FFMPEG_BINARY_RELEASE ||
   pkg['ffmpeg-static'].binary_release
 )
-const downloadUrl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${release}/${os.platform()}-${os.arch()}`
+const arch = process.env.npm_config_arch || os.arch()
+const platform = process.env.npm_config_platform || os.platform()
+const downloadUrl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${release}/${platform}-${arch}`
 const readmeUrl = `${downloadUrl}.README`
 const licenseUrl = `${downloadUrl}.LICENSE`
 


### PR DESCRIPTION
Try to use npm env-variables as source of target arch/platform, if not set fallback to os package