### PR TITLE
Update to include ffprobe

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -28,8 +28,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/darwin-x64
-          asset_name: darwin-x64
+          asset_path: bin/ffmpeg-darwin-x64
+          asset_name: ffmpeg-darwin-x64
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-darwin-x64
+          asset_name: ffprobe-darwin-x64
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1
@@ -46,8 +55,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/linux-arm
-          asset_name: linux-arm
+          asset_path: bin/ffmpeg-linux-arm
+          asset_name: ffmpeg-linux-arm
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-linux-arm
+          asset_name: ffprobe-linux-arm
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1
@@ -73,8 +91,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/linux-arm64
-          asset_name: linux-arm64
+          asset_path: bin/ffmpeg-linux-arm64
+          asset_name: ffmpeg-linux-arm64
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-linux-arm64
+          asset_name: ffprobe-linux-arm64
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1
@@ -100,8 +127,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/linux-ia32
-          asset_name: linux-ia32
+          asset_path: bin/ffmpeg-linux-ia32
+          asset_name: ffmpeg-linux-ia32
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-linux-ia32
+          asset_name: ffprobe-linux-ia32
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1
@@ -127,8 +163,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/linux-x64
-          asset_name: linux-x64
+          asset_path: bin/ffmpeg-linux-x64
+          asset_name: ffmpeg-linux-x64
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-linux-x64
+          asset_name: ffprobe-linux-x64
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1
@@ -154,8 +199,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/win32-ia32
-          asset_name: win32-ia32
+          asset_path: bin/ffmpeg-win32-ia32
+          asset_name: ffmpeg-win32-ia32
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-win32-ia32
+          asset_name: ffprobe-win32-ia32
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1
@@ -181,8 +235,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/win32-x64
-          asset_name: win32-x64
+          asset_path: bin/ffmpeg-win32-x64
+          asset_name: ffmpeg-win32-x64
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/ffprobe-win32-x64
+          asset_name: ffprobe-win32-x64
           asset_content_type: application/octet-stream
 
       - uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ bin/*
 /ffmpeg.exe
 /ffmpeg.README
 /ffmpeg.LICENSE
+/ffprobe
+/ffprobe.exe
+/ffprobe.README
+/ffprobe.LICENSE

--- a/README.md
+++ b/README.md
@@ -1,40 +1,44 @@
-# ffmpeg-static
+# ffmpeg-ffprobe-static
+
+Fork of [ffmpeg-static](https://github.com/eugeneware/ffmpeg-static) that includes ffprobe.
+
+## Info
 
 **[ffmpeg](https://ffmpeg.org) static binaries for Mac OSX and Linux and Windows.**
 
-Supports macOS (64-bit), Linux (32 and 64-bit, armhf, arm64) and Windows (32 and 64-bit). [The ffmpeg version currently used is `4.3.1`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.3.1)
+Supports macOS (64-bit), Linux (32 and 64-bit, armhf, arm64) and Windows (32 and 64-bit). [The ffmpeg version currently used is `4.3.1`.](https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/tag/b4.3.1)
 
-*Note:* The version of `ffmpeg-static` follows [SemVer](http://semver.org). When releasing new versions, **we do *not* consider breaking changes in `ffmpeg` itself**, but only the JS interface (see below). To stop `ffmpeg-static` from breaking your code by getting updated, [lock the version down](https://docs.npmjs.com/files/package.json#dependencies) or use a [lockfile](https://docs.npmjs.com/files/package-lock.json).
+*Note:* The version of `ffmpeg-ffprobe-static` follows [SemVer](http://semver.org). When releasing new versions, **we do *not* consider breaking changes in `ffmpeg` itself**, but only the JS interface (see below). To stop `ffmpeg-ffprobe-static` from breaking your code by getting updated, [lock the version down](https://docs.npmjs.com/files/package.json#dependencies) or use a [lockfile](https://docs.npmjs.com/files/package-lock.json).
 
-[![npm version](https://img.shields.io/npm/v/ffmpeg-static.svg)](https://www.npmjs.com/package/ffmpeg-static)
-[![build status](https://travis-ci.org/eugeneware/ffmpeg-static.svg?branch=master)](http://travis-ci.org/eugeneware/ffmpeg-static)
-![minimum Node.js version](https://img.shields.io/node/v/ffmpeg-static.svg)
+[![npm version](https://img.shields.io/npm/v/ffmpeg-ffprobe-static.svg)](https://www.npmjs.com/package/ffmpeg-ffprobe-static)
+[![Actions Status](https://github.com/descriptinc/ffmpeg-ffprobe-static/workflows/test/badge.svg)](https://github.com/descriptinc/ffmpeg-ffprobe-static/actions)
+![minimum Node.js version](https://img.shields.io/node/v/ffmpeg-ffprobe-static.svg)
 
 ## Installation
 
 This module is installed via npm:
 
 ``` bash
-$ npm install ffmpeg-static
+$ npm install ffmpeg-ffprobe-static
 ```
 
-*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b4.3.1` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.3.1). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
+*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b4.3.1` GitHub release](https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/tag/b4.3.1). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
 
 ### Electron & other cross-platform packaging tools
 
-Because `ffmpeg-static` will download a binary specific to the OS/platform, you need to purge `node_modules` before (re-)packaging your app *for a different OS/platform* ([read more in #35](https://github.com/eugeneware/ffmpeg-static/issues/35#issuecomment-630225392)).
+Because `ffmpeg-ffprobe-static` will download a binary specific to the OS/platform, you need to purge `node_modules` before (re-)packaging your app *for a different OS/platform* ([read more in #35](https://github.com/eugeneware/ffmpeg-static/issues/35#issuecomment-630225392)).
 
 ## Example Usage
 
 Returns the path of a statically linked ffmpeg binary on the local filesystem.
 
 ``` js
-var pathToFfmpeg = require('ffmpeg-static');
+var pathToFfmpeg = require('ffmpeg-ffprobe-static');
 console.log(pathToFfmpeg);
 ```
 
 ```
-/Users/j/playground/node_modules/ffmpeg-static/ffmpeg
+/Users/j/playground/node_modules/ffmpeg-ffprobe-static/ffmpeg
 ```
 
 Check the [example script](example.js) for a more thorough example.

--- a/build/index.sh
+++ b/build/index.sh
@@ -3,7 +3,7 @@ set -e
 cd $(dirname $0)
 
 set +e
-tar_exec=$(command -v gtar)
+tar_exec=$(command -v gtar) --wildcards --ignore-case
 if [ $? -ne 0 ]; then
 	tar_exec=$(command -v tar)
 fi
@@ -11,67 +11,76 @@ set -e
 echo using tar executable at $tar_exec
 
 download () {
-	curl -L -# --compressed -A 'https://github.com/eugeneware/ffmpeg-static' -o $2 $1
+  if [ -e $2 ]; then
+    echo "  already downloaded: $1"
+  else
+    echo "  downloading $2"
+    curl -L -# --compressed -A 'https://github.com/descriptinc/ffmpeg-ffprobe-static' -o $2 $1
+  fi
 }
 
 echo 'windows x64'
-echo '  downloading from ffmpeg.zeranoe.com'
 download 'https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3-win64-static.zip' win32-x64.zip
 echo '  extracting'
-unzip -o -d ../bin -j win32-x64.zip '**/ffmpeg.exe'
-mv ../bin/ffmpeg.exe ../bin/win32-x64
+unzip -o -d ../bin -j win32-x64.zip '**/ffmpeg.exe' '**/ffprobe.exe'
+mv ../bin/ffmpeg.exe ../bin/ffmpeg-win32-x64
+mv ../bin/ffprobe.exe ../bin/ffprobe-win32-x64
 unzip -p win32-x64.zip '**/LICENSE.txt' > ../bin/win32-x64.LICENSE
 unzip -p win32-x64.zip '**/README.txt' > ../bin/win32-x64.README
 
 echo 'windows ia32'
-echo '  downloading from ffmpeg.zeranoe.com'
 download 'https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.3-win32-static.zip' win32-ia32.zip
 echo '  extracting'
-unzip -o -d ../bin -j win32-ia32.zip '**/ffmpeg.exe'
-mv ../bin/ffmpeg.exe ../bin/win32-ia32
+unzip -o -d ../bin -j win32-ia32.zip '**/ffmpeg.exe' '**/ffprobe.exe'
+mv ../bin/ffmpeg.exe ../bin/ffmpeg-win32-ia32
+mv ../bin/ffprobe.exe ../bin/ffprobe-win32-ia32
 unzip -p win32-ia32.zip '**/LICENSE.txt' > ../bin/win32-ia32.LICENSE
 unzip -p win32-ia32.zip '**/README.txt' > ../bin/win32-ia32.README
 
 echo 'linux x64'
-echo '  downloading from johnvansickle.com'
 download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz' linux-x64.tar.xz
 echo '  extracting'
-$tar_exec -x -C ../bin --strip-components 1 -f linux-x64.tar.xz --wildcards '*/ffmpeg'
-mv ../bin/ffmpeg ../bin/linux-x64
-$tar_exec -x -f linux-x64.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-x64.LICENSE
-$tar_exec -x -f linux-x64.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-x64.README
+$tar_exec -x -C ../bin --strip-components 1 -f linux-x64.tar.xz '*/ffmpeg' '*/ffprobe'
+mv ../bin/ffmpeg ../bin/ffmpeg-linux-x64
+mv ../bin/ffprobe ../bin/ffprobe-linux-x64
+$tar_exec -x -f linux-x64.tar.xz -O '**/GPLv3.txt' > ../bin/linux-x64.LICENSE
+$tar_exec -x -f linux-x64.tar.xz -O '**/readme.txt' > ../bin/linux-x64.README
 
 echo 'linux ia32'
-echo '  downloading from johnvansickle.com'
 download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz' linux-ia32.tar.xz
 echo '  extracting'
-$tar_exec -x -C ../bin --strip-components 1 -f linux-ia32.tar.xz --wildcards '*/ffmpeg'
-mv ../bin/ffmpeg ../bin/linux-ia32
-$tar_exec -x -f linux-ia32.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-ia32.LICENSE
-$tar_exec -x -f linux-ia32.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-ia32.README
+$tar_exec -x -C ../bin --strip-components 1 -f linux-ia32.tar.xz '*/ffmpeg' '*/ffprobe'
+mv ../bin/ffmpeg ../bin/ffmpeg-linux-ia32
+mv ../bin/ffprobe ../bin/ffprobe-linux-ia32
+$tar_exec -x -f linux-ia32.tar.xz -O '**/GPLv3.txt' > ../bin/linux-ia32.LICENSE
+$tar_exec -x -f linux-ia32.tar.xz -O '**/readme.txt' > ../bin/linux-ia32.README
 
 echo 'linux arm'
-echo '  downloading from johnvansickle.com'
 download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-armhf-static.tar.xz' linux-arm.tar.xz
 echo '  extracting'
-$tar_exec -x -C ../bin --strip-components 1 -f linux-arm.tar.xz --wildcards '*/ffmpeg'
-mv ../bin/ffmpeg ../bin/linux-arm
-$tar_exec -x -f linux-arm.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-arm.LICENSE
-$tar_exec -x -f linux-arm.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-arm.README
+$tar_exec -x -C ../bin --strip-components 1 -f linux-arm.tar.xz '*/ffmpeg' '*/ffprobe'
+mv ../bin/ffmpeg ../bin/ffmpeg-linux-arm
+mv ../bin/ffprobe ../bin/ffprobe-linux-arm
+$tar_exec -x -f linux-arm.tar.xz -O '**/GPLv3.txt' > ../bin/linux-arm.LICENSE
+$tar_exec -x -f linux-arm.tar.xz -O '**/readme.txt' > ../bin/linux-arm.README
 
 echo 'linux arm64'
-echo '  downloading from johnvansickle.com'
 download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz' linux-arm64.tar.xz
 echo '  extracting'
-$tar_exec -x -C ../bin --strip-components 1 -f linux-arm64.tar.xz --wildcards '*/ffmpeg'
-mv ../bin/ffmpeg ../bin/linux-arm64
-$tar_exec -x -f linux-arm64.tar.xz --ignore-case --wildcards -O '**/GPLv3.txt' > ../bin/linux-arm64.LICENSE
-$tar_exec -x -f linux-arm64.tar.xz --ignore-case --wildcards -O '**/readme.txt' > ../bin/linux-arm64.README
+$tar_exec -x -C ../bin --strip-components 1 -f linux-arm64.tar.xz '*/ffmpeg' '*/ffprobe'
+mv ../bin/ffmpeg ../bin/ffmpeg-linux-arm64
+mv ../bin/ffprobe ../bin/ffprobe-linux-arm64
+$tar_exec -x -f linux-arm64.tar.xz -O '**/GPLv3.txt' > ../bin/linux-arm64.LICENSE
+$tar_exec -x -f linux-arm64.tar.xz -O '**/readme.txt' > ../bin/linux-arm64.README
 
 echo 'darwin x64'
-echo '  downloading from evermeet.cx'
-download 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip' darwin-x64.zip
+download 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip' ffmpeg-darwin-x64.zip
 echo '  extracting'
-unzip -o -d ../bin -j darwin-x64.zip ffmpeg
-mv ../bin/ffmpeg ../bin/darwin-x64
+unzip -o -d ../bin -j ffmpeg-darwin-x64.zip ffmpeg
+mv ../bin/ffmpeg ../bin/ffmpeg-darwin-x64
+
+download 'https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip' ffprobe-darwin-x64.zip
+echo '  extracting'
+unzip -o -d ../bin -j ffprobe-darwin-x64.zip ffprobe
+mv ../bin/ffprobe ../bin/ffprobe-darwin-x64
 curl -s -L 'https://evermeet.cx/ffmpeg/info/ffmpeg/release' | jq --tab '.' >../bin/darwin-x64.README

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+export const ffmpegPath: string | null;
+export const ffprobePath: string | null;

--- a/index.js
+++ b/index.js
@@ -1,28 +1,27 @@
 'use strict'
 
-if (process.env.FFMPEG_BIN) {
-  module.exports = process.env.FFMPEG_BIN
-} else {
-  var os = require('os')
-  var path = require('path')
+function getPath(name) {
+  const os = require('os')
+  const path = require('path')
 
-  var binaries = Object.assign(Object.create(null), {
+  const binaries = Object.assign(Object.create(null), {
     darwin: ['x64'],
     linux: ['x64', 'ia32', 'arm64', 'arm'],
     win32: ['x64', 'ia32']
   })
 
-  var platform = process.env.npm_config_platform || os.platform()
-  var arch = process.env.npm_config_arch || os.arch()
-
-  var ffmpegPath = path.join(
-    __dirname,
-    platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg'
-  )
+  const platform = process.env.npm_config_platform || os.platform()
+  const arch = process.env.npm_config_arch || os.arch()
 
   if (!binaries[platform] || binaries[platform].indexOf(arch) === -1) {
-    ffmpegPath = null
+    return null
   }
 
-  module.exports = ffmpegPath
+  return path.join(
+    __dirname,
+    platform === 'win32' ? name + '.exe' : name
+  )
 }
+
+exports.ffmpegPath = getPath('ffmpeg')
+exports.ffprobePath = getPath('ffprobe')

--- a/install.js
+++ b/install.js
@@ -8,7 +8,7 @@ const envPaths = require('env-paths')
 const FileCache = require('@derhuerst/http-basic/lib/FileCache').default
 var ProgressBar = require("progress");
 var request = require('@derhuerst/http-basic')
-var ffmpegPath = require(".");
+var {ffmpegPath, ffprobePath} = require(".");
 var pkg = require("./package");
 
 const exitOnError = (err) => {
@@ -20,13 +20,13 @@ const exitOnErrorOrWarnWith = (msg) => (err) => {
   else exitOnError(err)
 }
 
-if (!ffmpegPath) {
-  exitOnError('ffmpeg-static install failed: No binary found for architecture')
+if (!ffmpegPath || !ffprobePath) {
+  exitOnError('ffmpeg-ffprobe-static install failed: No binary found for architecture')
 }
 
 try {
-  if (fs.statSync(ffmpegPath).isFile()) {
-    console.info('ffmpeg is installed already.')
+  if (fs.statSync(ffmpegPath).isFile() && fs.statSync(ffprobePath).isFile()) {
+    console.info('ffmpeg/ffprobe is installed already.')
     process.exit(0)
   }
 } catch (err) {
@@ -142,13 +142,20 @@ const releaseName = (
 )
 const arch = process.env.npm_config_arch || os.arch()
 const platform = process.env.npm_config_platform || os.platform()
-const downloadUrl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${release}/${platform}-${arch}`
-const readmeUrl = `${downloadUrl}.README`
-const licenseUrl = `${downloadUrl}.LICENSE`
+let baseUrl = `https://github.com/descriptinc/ffmpeg-ffprobe-static/releases/download/${release}`;
+const ffmpegUrl = `${baseUrl}/ffmpeg-${platform}-${arch}`
+const ffprobeUrl = `${baseUrl}/ffprobe-${platform}-${arch}`
+const readmeUrl = `${baseUrl}/${platform}-${arch}.README`
+const licenseUrl = `${baseUrl}/${platform}-${arch}.LICENSE`
 
-downloadFile(downloadUrl, ffmpegPath, onProgress)
+downloadFile(ffmpegUrl, ffmpegPath, onProgress)
 .then(() => {
   fs.chmodSync(ffmpegPath, 0o755) // make executable
+})
+.catch(exitOnError)
+downloadFile(ffprobeUrl, ffprobePath, onProgress)
+.then(() => {
+  fs.chmodSync(ffprobePath, 0o755) // make executable
 })
 .catch(exitOnError)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ffmpeg-static",
+  "name": "ffmpeg-ffprobe-static",
   "version": "4.2.7",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "ffmpeg-static",
+  "name": "ffmpeg-ffprobe-static",
   "version": "4.2.7",
   "description": "ffmpeg static binaries for Mac OSX and Linux and Windows",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "index.js",
     "install.js",
@@ -20,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/eugeneware/ffmpeg-static"
+    "url": "https://github.com/descriptinc/ffmpeg-ffprobe-static"
   },
   "keywords": [
     "ffmpeg",
@@ -41,7 +42,7 @@
   ],
   "license": "GPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/eugeneware/ffmpeg-static/issues"
+    "url": "https://github.com/descriptinc/ffmpeg-ffprobe-static/issues"
   },
   "engines": {
     "node": ">=10"

--- a/test.js
+++ b/test.js
@@ -5,22 +5,34 @@ const {isAbsolute} = require('path')
 const fs = require('fs')
 const {spawnSync} = require('child_process')
 const shell = require('any-shell-escape')
-const ffmpegPath = require('.')
+const { ffmpegPath, ffprobePath } = require('.')
 
 console.info('TAP version 12')
-console.info('1..4')
+console.info('1..8')
 
 ok(isAbsolute(ffmpegPath))
-console.info('ok 1 - ffmpeg path is absolute')
+console.info('ok 1 - ffmpeg path is absolute')
+ok(isAbsolute(ffprobePath))
+console.info('ok 2 - ffprobe path is absolute')
 
 ok(fs.statSync(ffmpegPath).isFile(ffmpegPath))
-console.info(`ok 2 - ${ffmpegPath} is a file`)
+console.info(`ok 3 - ${ffmpegPath} is a file`)
+ok(fs.statSync(ffprobePath).isFile(ffprobePath))
+console.info(`ok 4 - ${ffprobePath} is a file`)
 
 fs.accessSync(ffmpegPath, fs.constants.X_OK)
-console.info(`ok 3 - ${ffmpegPath} is executable`)
+console.info(`ok 5 - ${ffmpegPath} is executable`)
+fs.accessSync(ffprobePath, fs.constants.X_OK)
+console.info(`ok 6 - ${ffprobePath} is executable`)
 
-const {status} = spawnSync(ffmpegPath, ['--help'], {
+const spawnFfmpeg = spawnSync(ffmpegPath, ['--help'], {
 	stdio: ['ignore', 'ignore', 'pipe'], // stdin, stdout, stderr
 })
-strictEqual(status, 0)
-console.info(`ok 4 - \`${ffmpegPath} --help\` works`)
+strictEqual(spawnFfmpeg.status, 0)
+console.info(`ok 7 - \`${ffmpegPath} --help\` works`)
+
+const spawnFfprobe = spawnSync(ffprobePath, ['--help'], {
+	stdio: ['ignore', 'ignore', 'pipe'], // stdin, stdout, stderr
+})
+strictEqual(spawnFfprobe.status, 0)
+console.info(`ok 8 - \`${ffprobePath} --help\` works`)


### PR DESCRIPTION
- rename from ffmpeg-static to ffmpeg-ffprobe-static
- update index.js to export both ffmpegPath and ffprobePath
- add index.d.ts for TypeScript
- do not download if the file is already downloaded
- unzip both ffmpeg and ffprobe to bin/ffmpeg-* and bin/ffprobe-*
- add darwin ffprobe download (separate zip)
- update github workflow to upload ffmpeg/ffprobe files with new names
- add github workflow for running test (instead of travis)
- fix tar commands on macos (hope it doesn't break linux)
- add ffprobe tests