### PR TITLE
support darwin-arm64

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -19,6 +19,7 @@ jobs:
           set -e
           set -o pipefail
           cat bin/darwin-x64 | gzip --best >bin/darwin-x64.gz
+          cat bin/darwin-arm64 | gzip --best >bin/darwin-arm64.gz
           cat bin/freebsd-x64 | gzip --best >bin/freebsd-x64.gz
           cat bin/linux-arm | gzip --best >bin/linux-arm.gz
           cat bin/linux-arm64 | gzip --best >bin/linux-arm64.gz
@@ -62,6 +63,32 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bin/darwin-x64.README
           asset_name: darwin-x64.README
+          asset_content_type: text/plain
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/darwin-arm64
+          asset_name: darwin-arm64
+          asset_content_type: application/octet-stream
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/darwin-arm64.gz
+          asset_name: darwin-arm64.gz
+          asset_content_type: application/octet-stream
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/darwin-arm64.README
+          asset_name: darwin-arm64.README
           asset_content_type: text/plain
 
       - uses: actions/upload-release-asset@v1.0.1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Check the [example script](example.js) for a more thorough example.
 
 - [Windows builds](https://github.com/ShareX/FFmpeg/)
 - [Linux builds](https://johnvansickle.com/ffmpeg/)
-- macOS builds [for Intel](https://evermeet.cx/pub/ffmpeg/) / [for ARM (Apple Silicon)](http://osxexperts.net/)
+- macOS builds [for Intel](https://evermeet.cx/pub/ffmpeg/) / [for ARM (Apple Silicon)](https://osxexperts.net/)
 - [FreeBSD builds](https://github.com/Thefrank/ffmpeg-static-freebsd/releases)
 
 The build script extracts build information and (when possible) the license file from the downloaded package or the distribution server. Please consult the individual build's project site for exact source versions, which you can locate based on the version information included in the README file.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[ffmpeg](https://ffmpeg.org) static binaries for Mac OSX, Linux, Windows and FreeBSD.**
 
-Supports macOS (64-bit), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit) and FreeBSD (64-bit). [The ffmpeg version currently used is `4.3.2`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.3.2)
+Supports macOS (64-bit, arm64), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit) and FreeBSD (64-bit). [The ffmpeg version currently used is `4.3.2`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.3.2)
 
 *Note:* The version of `ffmpeg-static` follows [SemVer](http://semver.org). When releasing new versions, **we do *not* consider breaking changes in `ffmpeg` itself**, but only the JS interface (see below). To stop `ffmpeg-static` from breaking your code by getting updated, [lock the version down](https://docs.npmjs.com/files/package.json#dependencies) or use a [lockfile](https://docs.npmjs.com/files/package-lock.json).
 
@@ -45,7 +45,7 @@ Check the [example script](example.js) for a more thorough example.
 
 - [Windows builds](https://github.com/ShareX/FFmpeg/)
 - [Linux builds](https://johnvansickle.com/ffmpeg/)
-- [macOS builds](https://evermeet.cx/pub/ffmpeg/)
+- macOS builds [for Intel](https://evermeet.cx/pub/ffmpeg/) / [for ARM (Apple Silicon)](http://osxexperts.net/)
 - [FreeBSD builds](https://github.com/Thefrank/ffmpeg-static-freebsd/releases)
 
 The build script extracts build information and (when possible) the license file from the downloaded package or the distribution server. Please consult the individual build's project site for exact source versions, which you can locate based on the version information included in the README file.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[ffmpeg](https://ffmpeg.org) static binaries for Mac OSX, Linux, Windows and FreeBSD.**
 
-Supports macOS (64-bit, arm64), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit) and FreeBSD (64-bit). [The ffmpeg version currently used is `4.3.2`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.3.2)
+Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit) and FreeBSD (64-bit). [The ffmpeg version currently used is `4.3.2`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.3.2)
 
 *Note:* The version of `ffmpeg-static` follows [SemVer](http://semver.org). When releasing new versions, **we do *not* consider breaking changes in `ffmpeg` itself**, but only the JS interface (see below). To stop `ffmpeg-static` from breaking your code by getting updated, [lock the version down](https://docs.npmjs.com/files/package.json#dependencies) or use a [lockfile](https://docs.npmjs.com/files/package-lock.json).
 

--- a/build/index.sh
+++ b/build/index.sh
@@ -76,6 +76,7 @@ download 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip' darwin-x64.zip
 echo '  extracting'
 unzip -o -d ../bin -j darwin-x64.zip ffmpeg
 mv ../bin/ffmpeg ../bin/darwin-x64
+curl -s -L 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/HEAD:/LICENSE.md'  -o ../bin/darwin-x64.LICENSE
 curl -s -L 'https://evermeet.cx/ffmpeg/info/ffmpeg/release' | jq --tab '.' >../bin/darwin-x64.README
 
 echo 'darwin arm64'

--- a/build/index.sh
+++ b/build/index.sh
@@ -78,6 +78,14 @@ unzip -o -d ../bin -j darwin-x64.zip ffmpeg
 mv ../bin/ffmpeg ../bin/darwin-x64
 curl -s -L 'https://evermeet.cx/ffmpeg/info/ffmpeg/release' | jq --tab '.' >../bin/darwin-x64.README
 
+echo 'darwin arm64'
+echo '  downloading from osxexperts.net'
+download 'https://www.osxexperts.net/ffmpeg44arm.zip' darwin-arm64.zip
+echo '  extracting'
+unzip -o -d ../bin -j darwin-arm64.zip ffmpeg
+mv ../bin/ffmpeg ../bin/darwin-arm64
+curl -s -L 'http://osxexperts.net/'  -o ../bin/darwin-arm64.README
+
 echo 'freebsd x64'
 echo '  downloading from github.com/Thefrank/ffmpeg-static-freebsd'
 download 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v4.3.2/ffmpeg' ../bin/freebsd

--- a/build/index.sh
+++ b/build/index.sh
@@ -84,7 +84,8 @@ download 'https://www.osxexperts.net/ffmpeg44arm.zip' darwin-arm64.zip
 echo '  extracting'
 unzip -o -d ../bin -j darwin-arm64.zip ffmpeg
 mv ../bin/ffmpeg ../bin/darwin-arm64
-curl -s -L 'http://osxexperts.net/'  -o ../bin/darwin-arm64.README
+curl -s -L 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/HEAD:/LICENSE.md'  -o ../bin/darwin-arm64.LICENSE
+curl -s -L 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/HEAD:/README.md'  -o ../bin/darwin-arm64.README
 
 echo 'freebsd x64'
 echo '  downloading from github.com/Thefrank/ffmpeg-static-freebsd'

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ if (process.env.FFMPEG_BIN) {
   var path = require('path')
 
   var binaries = Object.assign(Object.create(null), {
-    darwin: ['x64'],
+    darwin: ['x64', 'arm64'],
     freebsd: ['x64'],
     linux: ['x64', 'ia32', 'arm64', 'arm'],
     win32: ['x64', 'ia32']


### PR DESCRIPTION
Closes #49 

running the build script seems to function as expected but I will need some help with regards to the cached releases and updating the relevant portions of the project README (is the ffmpeg version being bumped? etc). also unsure if curling the osxexperts page is sufficient for a `darwin-arm64.README`