### PR TITLE
Support configure FFMPEG_BINARIES_URL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,23 @@ $ npm install ffmpeg-static
 
 ### Custom binaries url
 
-To use a mirror of the ffmpeg-static binaries use npm config property `ffmpegstatic_cdnurl`.
+To use a mirror of the ffmpeg-static binaries use npm config property `ffmpeg_binaries_url`.
 Default is `https://github.com/eugeneware/ffmpeg-static/releases/download`.
 
 ```shell
-npm install ffmpeg-static --ffmpegstatic_cdnurl=https://cdn.npmmirror.com/binaries/ffmpeg-static
+npm install ffmpeg-static --ffmpeg_binaries_url=https://cdn.npmmirror.com/binaries/ffmpeg-static
 ```
 
 Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
 
 ```
-ffmpegstatic_cdnurl=https://cdn.npmmirror.com/binaries/ffmpeg-static
+ffmpeg_binaries_url=https://cdn.npmmirror.com/binaries/ffmpeg-static
 ```
 
-Another option is to use PATH variable `FFMPEGSTATIC_CDNURL`.
+Another option is to use PATH variable `FFMPEG_BINARIES_URL`.
 
 ```shell
-FFMPEGSTATIC_CDNURL=https://cdn.npmmirror.com/binaries/ffmpeg-static npm install ffmpeg-static
+FFMPEG_BINARIES_URL=https://cdn.npmmirror.com/binaries/ffmpeg-static npm install ffmpeg-static
 ```
 
 ### Electron & other cross-platform packaging tools

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
 ffmpeg_binaries_url=https://cdn.npmmirror.com/binaries/ffmpeg-static
 ```
 
-Another option is to use PATH variable `FFMPEG_BINARIES_URL`.
+Another option is to use the `FFMPEG_BINARIES_URL` environment variable.
 
 ```shell
-FFMPEG_BINARIES_URL=https://cdn.npmmirror.com/binaries/ffmpeg-static npm install ffmpeg-static
+env export FFMPEG_BINARIES_URL=https://cdn.npmmirror.com/binaries/ffmpeg-static npm install ffmpeg-static
 ```
 
 ### Electron & other cross-platform packaging tools

--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ $ npm install ffmpeg-static
 
 *Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b4.4.1` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.4.1). Use and distribution of the binary releases of FFmpeg are covered by their respective license.
 
+### Custom binaries url
+
+To use a mirror of the ffmpeg-static binaries use npm config property `ffmpegstatic_cdnurl`.
+Default is `https://github.com/eugeneware/ffmpeg-static/releases/download`.
+
+```shell
+npm install ffmpeg-static --ffmpegstatic_cdnurl=https://cdn.npmmirror.com/binaries/ffmpeg-static
+```
+
+Or add property into your [`.npmrc`](https://docs.npmjs.com/files/npmrc) file.
+
+```
+ffmpegstatic_cdnurl=https://cdn.npmmirror.com/binaries/ffmpeg-static
+```
+
+Another option is to use PATH variable `FFMPEGSTATIC_CDNURL`.
+
+```shell
+FFMPEGSTATIC_CDNURL=https://cdn.npmmirror.com/binaries/ffmpeg-static npm install ffmpeg-static
+```
+
 ### Electron & other cross-platform packaging tools
 
 Because `ffmpeg-static` will download a binary specific to the OS/platform, you need to purge `node_modules` before (re-)packaging your app *for a different OS/platform* ([read more in #35](https://github.com/eugeneware/ffmpeg-static/issues/35#issuecomment-630225392)).

--- a/install.js
+++ b/install.js
@@ -161,8 +161,8 @@ const releaseName = (
 )
 const arch = process.env.npm_config_arch || os.arch()
 const platform = process.env.npm_config_platform || os.platform()
-
-const baseUrl = `https://github.com/eugeneware/ffmpeg-static/releases/download/${release}`
+const cdnUrl = process.env.npm_config_ffmpegstatic_cdnurl || process.env.FFMPEGSTATIC_CDNURL || 'https://github.com/eugeneware/ffmpeg-static/releases/download'
+const baseUrl = `${cdnUrl}/${release}`
 const downloadUrl = `${baseUrl}/${platform}-${arch}.gz`
 const readmeUrl = `${baseUrl}/${platform}-${arch}.README`
 const licenseUrl = `${baseUrl}/${platform}-${arch}.LICENSE`

--- a/install.js
+++ b/install.js
@@ -161,7 +161,7 @@ const releaseName = (
 )
 const arch = process.env.npm_config_arch || os.arch()
 const platform = process.env.npm_config_platform || os.platform()
-const cdnUrl = process.env.npm_config_ffmpegstatic_cdnurl || process.env.FFMPEGSTATIC_CDNURL || 'https://github.com/eugeneware/ffmpeg-static/releases/download'
+const cdnUrl = process.env.npm_config_ffmpeg_binaries_url || process.env.FFMPEG_BINARIES_URL || 'https://github.com/eugeneware/ffmpeg-static/releases/download'
 const baseUrl = `${cdnUrl}/${release}`
 const downloadUrl = `${baseUrl}/${platform}-${arch}.gz`
 const readmeUrl = `${baseUrl}/${platform}-${arch}.README`


### PR DESCRIPTION
```
npm install ffmpeg-static --ffmpeg_binaries_url=https://cdn.npmmirror.com/binaries/ffmpeg-static

FFMPEG_BINARIES_URL=https://cdn.npmmirror.com/binaries/ffmpeg-static npm install ffmpeg-static
```

@derhuerst 