### PR TITLE
Update downloadsUrl to prioritize .npmrc variable

### DIFF
--- a/install.js
+++ b/install.js
@@ -167,6 +167,7 @@ const release = (
 const arch = process.env.npm_config_arch || os.arch()
 const platform = process.env.npm_config_platform || os.platform()
 const downloadsUrl = (
+  process.env.npm_config_ffmpeg_binaries_url ||
   process.env[BINARIES_URL_ENV_VAR] ||
   'https://github.com/eugeneware/ffmpeg-static/releases/download'
 )


### PR DESCRIPTION
This commit updates the `downloadsUrl` variable to prioritize the value from the `.npmrc` file if it exists. The updated code checks `process.env.npm_config_ffmpeg_binaries_url` first and if it's not set, then it falls back to `process.env[BINARIES_URL_ENV_VAR]` or the default value if none of the variables are set. This change allows for more flexibility and customization when it comes to configuring the download URL for ffmpeg binaries.