### PR TITLE
Add pretest script to download binaries before running test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   	"packages/ffprobe-static"
   ],
   "scripts": {
+    "pretest": "npm run build && npm install",
     "test": "node test.js",
     "lint": "eslint .",
     "build": "./build-packages.js",


### PR DESCRIPTION
This adds a pretest script to download both binaries simultaneously before running the tests.

Without doing this an error is thrown as the binary doesn't exist.  It makes sense to at least have them downloaded before even attempting to run the tests.