### PR TITLE
Support --os, --cpu args of higher version of npm install

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ if (process.env[BINARY_PATH_ENV_VAR]) {
     win32: ['x64', 'ia32']
   })
 
-  var platform = process.env.npm_config_platform || os.platform()
-  var arch = process.env.npm_config_arch || os.arch()
+  var platform = process.env.npm_config_os || process.env.npm_config_platform || os.platform()
+  var arch = process.env.npm_config_cpu || process.env.npm_config_arch || os.arch()
 
   let binaryPath = path.join(
     __dirname,

--- a/install.js
+++ b/install.js
@@ -164,8 +164,8 @@ const release = (
   process.env[RELEASE_ENV_VAR] ||
   pkg[pkg.name]['binary-release-tag']
 )
-const arch = process.env.npm_config_arch || os.arch()
-const platform = process.env.npm_config_platform || os.platform()
+const arch = process.env.npm_config_cpu || process.env.npm_config_arch || os.arch()
+const platform = process.env.npm_config_os || process.env.npm_config_platform || os.platform()
 const downloadsUrl = (
   process.env[BINARIES_URL_ENV_VAR] ||
   'https://github.com/eugeneware/ffmpeg-static/releases/download'


### PR DESCRIPTION
--arch and --platform are still works.
But it is changed to --cpu and --os in newer version of npm.
And that is not copied to env.npm_config_arch/platform.