### PR TITLE
Upgrade ffmpeg to 8.0.1, switch Linux x64/arm64 to BtbN builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Static **[ffmpeg](https://ffmpeg.org)/ffprobe binaries for macOS, Linux, Windows.**
 
-Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit). [The ffmpeg version currently used is `6.1.1`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b6.1.1)
+Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (64-bit). [The ffmpeg version currently used is `8.0.1`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b8.0.1)
 
 [![npm version](https://img.shields.io/npm/v/ffmpeg-static.svg)](https://www.npmjs.com/package/ffmpeg-static)
 ![minimum Node.js version](https://img.shields.io/node/v/ffmpeg-static.svg)
@@ -12,8 +12,7 @@ Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows 
 [The binaries download script](download-binaries/index.sh) downloads binaries from these locations:
 
 - [Windows x64 builds](https://www.gyan.dev/ffmpeg/builds/)
-- [Windows x86 builds](https://github.com/sudo-nautilus/FFmpeg-Builds-Win32/)
-- [Linux x64/x86/ARM/ARM64 builds](https://johnvansickle.com/ffmpeg/)
+- [Linux x64/ARM64 builds](https://github.com/BtbN/FFmpeg-Builds) & [x86/ARM builds](https://johnvansickle.com/ffmpeg/)
 - macOS [x64 (Intel)](https://evermeet.cx/pub/ffmpeg/) & [ARM64 (Apple Silicon)](https://osxexperts.net/) builds
 
 The script extracts build information and (when possible) the license file from the downloaded package or the distribution server. Please consult the individual build's project site for exact source versions, which you can locate based on the version information included in the README file.

--- a/download-binaries/index.sh
+++ b/download-binaries/index.sh
@@ -38,8 +38,7 @@ set -x # todo: remove
 
 echo 'windows x64'
 echo '  downloading from github.com/GyanD/codexffmpeg'
-# todo: 404
-download 'https://github.com/GyanD/codexffmpeg/releases/download/6.1.1/ffmpeg-6.1.1-essentials_build.7z' win32-x64.7z
+download 'https://github.com/GyanD/codexffmpeg/releases/download/8.0.1/ffmpeg-8.0.1-essentials_build.7z' win32-x64.7z
 echo '  extracting'
 tmpdir=$(mktemp -d)
 $p7zip_exec e -y -bd -o"$tmpdir" win32-x64.7z >/dev/null
@@ -60,17 +59,17 @@ mv "$tmpdir/README.txt" ../bin/win32-x64.README
 # # curl -fsSL 'https://raw.githubusercontent.com/sudo-nautilus/FFmpeg-Builds-Win32/autobuild-2022-04-30-14-19/LICENSE' -o ../bin/win32-ia32.LICENSE
 
 echo 'linux x64'
-echo '  downloading from johnvansickle.com'
-download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz' linux-x64.tar.xz
+echo '  downloading from github.com/BtbN/FFmpeg-Builds'
+download 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.0-latest-linux64-gpl-8.0.tar.xz' linux-x64.tar.xz
 echo '  extracting'
-xzcat linux-x64.tar.xz | $tar_exec -x -C ../bin --strip-components 1 --wildcards '*/ffmpeg' '*/ffprobe'
+xzcat linux-x64.tar.xz | $tar_exec -x -C ../bin --strip-components 2 --wildcards '*/bin/ffmpeg' '*/bin/ffprobe'
 mv ../bin/ffmpeg ../bin/ffmpeg-linux-x64
 mv ../bin/ffprobe ../bin/ffprobe-linux-x64
-xzcat linux-x64.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/GPLv3.txt' >../bin/linux-x64.LICENSE
-xzcat linux-x64.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/readme.txt' >../bin/linux-x64.README
+xzcat linux-x64.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/LICENSE.txt' >../bin/linux-x64.LICENSE
+curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n8.0.1:/README.md' -o ../bin/linux-x64.README
 
 echo 'linux ia32'
-echo '  downloading from johnvansickle.com'
+echo '  downloading from johnvansickle.com (BtbN does not support ia32)'
 download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz' linux-ia32.tar.xz
 echo '  extracting'
 xzcat linux-ia32.tar.xz | $tar_exec -x -C ../bin --strip-components 1 --wildcards '*/ffmpeg' '*/ffprobe'
@@ -80,7 +79,7 @@ xzcat linux-ia32.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/GPLv3.tx
 xzcat linux-ia32.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/readme.txt' >../bin/linux-ia32.README
 
 echo 'linux arm'
-echo '  downloading from johnvansickle.com'
+echo '  downloading from johnvansickle.com (BtbN does not support armhf)'
 download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-armhf-static.tar.xz' linux-arm.tar.xz
 echo '  extracting'
 xzcat linux-arm.tar.xz | $tar_exec -x -C ../bin --strip-components 1 --wildcards '*/ffmpeg' '*/ffprobe'
@@ -90,45 +89,44 @@ xzcat linux-arm.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/GPLv3.txt
 xzcat linux-arm.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/readme.txt' >../bin/linux-arm.README
 
 echo 'linux arm64'
-echo '  downloading from johnvansickle.com'
-download 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz' linux-arm64.tar.xz
+echo '  downloading from github.com/BtbN/FFmpeg-Builds'
+download 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.0-latest-linuxarm64-gpl-8.0.tar.xz' linux-arm64.tar.xz
 echo '  extracting'
-xzcat linux-arm64.tar.xz | $tar_exec -x -C ../bin --strip-components 1 --wildcards '*/ffmpeg' '*/ffprobe'
+xzcat linux-arm64.tar.xz | $tar_exec -x -C ../bin --strip-components 2 --wildcards '*/bin/ffmpeg' '*/bin/ffprobe'
 mv ../bin/ffmpeg ../bin/ffmpeg-linux-arm64
 mv ../bin/ffprobe ../bin/ffprobe-linux-arm64
-xzcat linux-arm64.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/GPLv3.txt' >../bin/linux-arm64.LICENSE
-xzcat linux-arm64.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/readme.txt' >../bin/linux-arm64.README
+xzcat linux-arm64.tar.xz | $tar_exec -x --ignore-case --wildcards -O '**/LICENSE.txt' >../bin/linux-arm64.LICENSE
+curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n8.0.1:/README.md' -o ../bin/linux-arm64.README
 
 echo 'darwin x64'
 echo '  downloading from evermeet.cx'
-download $(curl 'https://evermeet.cx/ffmpeg/info/ffmpeg/6.1.1' -fsS| jq -rc '.download.zip.url') ffmpeg-darwin-x64.zip
-download $(curl 'https://evermeet.cx/ffmpeg/info/ffprobe/6.1.1' -fsS| jq -rc '.download.zip.url') ffprobe-darwin-x64.zip
+download $(curl 'https://evermeet.cx/ffmpeg/info/ffmpeg/8.0.1' -fsS| jq -rc '.download.zip.url') ffmpeg-darwin-x64.zip
+download $(curl 'https://evermeet.cx/ffmpeg/info/ffprobe/8.0.1' -fsS| jq -rc '.download.zip.url') ffprobe-darwin-x64.zip
 echo '  extracting'
 unzip -o -d ../bin -j ffmpeg-darwin-x64.zip ffmpeg
 unzip -o -d ../bin -j ffprobe-darwin-x64.zip ffprobe
 mv ../bin/ffmpeg ../bin/ffmpeg-darwin-x64
 mv ../bin/ffprobe ../bin/ffprobe-darwin-x64
-curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/HEAD:/LICENSE.md'  -o ../bin/darwin-x64.LICENSE
+curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n8.0.1:/LICENSE.md'  -o ../bin/darwin-x64.LICENSE
 curl -fsSL 'https://evermeet.cx/ffmpeg/info/ffmpeg/release' | jq --tab '.' >../bin/darwin-x64.README
-# todo: pull ffprobe README?
 
 echo 'darwin arm64'
 echo '  downloading from osxexperts.net'
-download 'https://www.osxexperts.net/ffmpeg6arm.zip' ffmpeg-darwin-arm64.zip
-download 'https://www.osxexperts.net/ffprobe6arm.zip' ffprobe-darwin-arm64.zip
+download 'https://www.osxexperts.net/ffmpeg80arm.zip' ffmpeg-darwin-arm64.zip
+download 'https://www.osxexperts.net/ffprobe80arm.zip' ffprobe-darwin-arm64.zip
 echo '  extracting'
 unzip -o -d ../bin -j ffmpeg-darwin-arm64.zip ffmpeg
 unzip -o -d ../bin -j ffprobe-darwin-arm64.zip ffprobe
 mv ../bin/ffmpeg ../bin/ffmpeg-darwin-arm64
 mv ../bin/ffprobe ../bin/ffprobe-darwin-arm64
-curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n6.1.1:/LICENSE.md'  -o ../bin/darwin-arm64.LICENSE
-curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n6.1.1:/README.md'  -o ../bin/darwin-arm64.README
+curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n8.0.1:/LICENSE.md'  -o ../bin/darwin-arm64.LICENSE
+curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n8.0.1:/README.md'  -o ../bin/darwin-arm64.README
 
 # echo 'freebsd x64'
 # echo '  downloading from github.com/Thefrank/ffmpeg-static-freebsd'
-# download 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v6.1.1/ffmpeg' ../bin/ffmpeg-freebsd-x64
-# download 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v6.1.1/ffprobe' ../bin/ffprobe-freebsd-x64
+# download 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v8.0.1/ffmpeg' ../bin/ffmpeg-freebsd-x64
+# download 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v8.0.1/ffprobe' ../bin/ffprobe-freebsd-x64
 # chmod +x ../bin/ffmpeg-freebsd-x64
 # chmod +x ../bin/ffprobe-freebsd-x64
-# curl -fsSL 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v6.1.1/GPLv3.LICENSE' -o ../bin/freebsd-x64.LICENSE
-# curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n6.1.1:/README.md' -o ../bin/freebsd-x64.README
+# curl -fsSL 'https://github.com/Thefrank/ffmpeg-static-freebsd/releases/download/v8.0.1/GPLv3.LICENSE' -o ../bin/freebsd-x64.LICENSE
+# curl -fsSL 'https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/n8.0.1:/README.md' -o ../bin/freebsd-x64.README

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "ffmpeg-static": {
     "binary-path-env-var": "FFMPEG_BIN",
     "binary-release-tag-env-var": "FFMPEG_BINARY_RELEASE",
-    "binary-release-tag": "b6.1.1",
+    "binary-release-tag": "b8.0.1",
     "binaries-url-env-var": "FFMPEG_BINARIES_URL",
     "executable-base-name": "ffmpeg"
   },
   "@derhuerst/ffprobe-static": {
     "binary-path-env-var": "FFPROBE_BIN",
     "binary-release-tag-env-var": "FFPROBE_BINARY_RELEASE",
-    "binary-release-tag": "b6.1.1",
+    "binary-release-tag": "b8.0.1",
     "binaries-url-env-var": "FFPROBE_BINARIES_URL",
     "executable-base-name": "ffprobe"
   },

--- a/packages/ffmpeg-static/README.md
+++ b/packages/ffmpeg-static/README.md
@@ -2,7 +2,7 @@
 
 Static **[ffmpeg](https://ffmpeg.org) binaries for macOS, Linux, Windows.**
 
-Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit). [The ffmpeg version currently used is `6.1.1`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b6.1.1)
+Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (64-bit). [The ffmpeg version currently used is `8.0.1`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b8.0.1)
 
 [![npm version](https://img.shields.io/npm/v/ffmpeg-static.svg)](https://www.npmjs.com/package/ffmpeg-static)
 ![minimum Node.js version](https://img.shields.io/node/v/ffmpeg-static.svg)
@@ -17,7 +17,7 @@ Also check out [`node-ffmpeg-installer`](https://github.com/kribblo/node-ffmpeg-
 $ npm install ffmpeg-static
 ```
 
-*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b6.1.1` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b6.1.1). Use and distribution of the binary releases of `ffmpeg` are covered by their respective license.
+*Note:* During installation, it will download the appropriate `ffmpeg` binary from the [`b8.0.1` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b8.0.1). Use and distribution of the binary releases of `ffmpeg` are covered by their respective license.
 
 ### Custom binaries url
 
@@ -49,8 +49,7 @@ Check the [example script](example.js) for a more thorough example.
 The binaries downloaded by `ffmpeg-static` are from these locations:
 
 - [Windows x64 builds](https://www.gyan.dev/ffmpeg/builds/)
-- [Windows x86 builds](https://github.com/sudo-nautilus/FFmpeg-Builds-Win32/)
-- [Linux x64/x86/ARM/ARM64 builds](https://johnvansickle.com/ffmpeg/)
+- [Linux x64/ARM64 builds](https://github.com/BtbN/FFmpeg-Builds) & [x86/ARM builds](https://johnvansickle.com/ffmpeg/)
 - macOS [x64 (Intel)](https://evermeet.cx/pub/ffmpeg/) & [ARM64 (Apple Silicon)](https://osxexperts.net/) builds
 
 ## Show your support

--- a/packages/ffprobe-static/README.md
+++ b/packages/ffprobe-static/README.md
@@ -2,7 +2,7 @@
 
 Static **ffprobe (from the [ffmpeg](https://ffmpeg.org) project) binaries for macOS, Linux, Windows.**
 
-Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (32 and 64-bit). [The ffmpeg version currently used is `6.1.1`.](https://github.com/eugeneware/ffprobe-static/releases/tag/b6.1.1)
+Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows (64-bit). [The ffmpeg version currently used is `8.0.1`.](https://github.com/eugeneware/ffmpeg-static/releases/tag/b8.0.1)
 
 [![npm version](https://img.shields.io/npm/v/ffprobe-static.svg)](https://www.npmjs.com/package/ffprobe-static)
 ![minimum Node.js version](https://img.shields.io/node/v/ffprobe-static.svg)
@@ -15,7 +15,7 @@ Supports macOS (64-bit and arm64), Linux (32 and 64-bit, armhf, arm64), Windows 
 $ npm install @derhuerst/ffprobe-static
 ```
 
-*Note:* During installation, it will download the appropriate `ffprobe` binary from the [`b6.1.1` GitHub release](https://github.com/eugeneware/ffprobe-static/releases/tag/b6.1.1). Use and distribution of the binary releases of `ffprobe` are covered by their respective license.
+*Note:* During installation, it will download the appropriate `ffprobe` binary from the [`b8.0.1` GitHub release](https://github.com/eugeneware/ffmpeg-static/releases/tag/b8.0.1). Use and distribution of the binary releases of `ffprobe` are covered by their respective license.
 
 ### Custom binaries url
 
@@ -47,8 +47,7 @@ Check the [example script](example.js) for a more thorough example.
 The binaries downloaded by `ffprobe-static` are from these locations:
 
 - [Windows x64 builds](https://www.gyan.dev/ffmpeg/builds/)
-- [Windows x86 builds](https://github.com/sudo-nautilus/FFmpeg-Builds-Win32/)
-- [Linux x64/x86/ARM/ARM64 builds](https://johnvansickle.com/ffmpeg/)
+- [Linux x64/ARM64 builds](https://github.com/BtbN/FFmpeg-Builds) & [x86/ARM builds](https://johnvansickle.com/ffmpeg/)
 - macOS [x64 (Intel)](https://evermeet.cx/pub/ffmpeg/) & [ARM64 (Apple Silicon)](https://osxexperts.net/) builds
 
 ## Show your support


### PR DESCRIPTION
Closes #146, #145, #137

## Summary

This PR upgrades ffmpeg/ffprobe binaries from **6.1.1** to **8.0.1** across all supported platforms.

## Why the Linux source change?

The previous Linux binary source ([johnvansickle.com](https://johnvansickle.com/ffmpeg/)) has not yet updated to ffmpeg 8.x - their latest release builds are still at **7.0.2**. To provide 8.0.1 binaries, this PR switches the Linux x64 and arm64 builds to [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds), which maintains up-to-date static builds.

**Note:** BtbN does not provide builds for 32-bit architectures (ia32, armhf). For these platforms, we continue using johnvansickle.com, which means they will receive whatever version johnvansickle currently provides (7.0.2 at time of writing). This is a trade-off to maintain support for these less common architectures.

## Binary sources by platform

| Platform | Architecture | Source | Version |
|----------|-------------|--------|---------|
| **Windows** | x64 | [GyanD/codexffmpeg](https://github.com/GyanD/codexffmpeg) | 8.0.1 |
| **Linux** | x64 | [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) | 8.0 |
| **Linux** | arm64 | [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) | 8.0 |
| **Linux** | ia32 | [johnvansickle.com](https://johnvansickle.com/ffmpeg/) | 7.0.2* |
| **Linux** | armhf | [johnvansickle.com](https://johnvansickle.com/ffmpeg/) | 7.0.2* |
| **macOS** | x64 (Intel) | [evermeet.cx](https://evermeet.cx/ffmpeg/) | 8.0.1 |
| **macOS** | arm64 (Apple Silicon) | [osxexperts.net](https://osxexperts.net/) | 8.0 |

*\* johnvansickle.com uses rolling "release" URLs - version depends on their latest build*

## Changes

### `download-binaries/index.sh`
- Updated Windows x64 URL to fetch 8.0.1 from GyanD
- **Switched** Linux x64 from johnvansickle.com to BtbN (`ffmpeg-n8.0-latest-linux64-gpl-8.0.tar.xz`)
- **Switched** Linux arm64 from johnvansickle.com to BtbN (`ffmpeg-n8.0-latest-linuxarm64-gpl-8.0.tar.xz`)
- Updated extraction for BtbN archives (different directory structure: `--strip-components 2` + `*/bin/ffmpeg`)
- Kept Linux ia32/armhf on johnvansickle.com (added comments explaining why)
- Updated macOS x64 evermeet.cx API calls to request version 8.0.1
- Updated macOS arm64 URLs from `ffmpeg6arm.zip` to `ffmpeg80arm.zip`
- Updated all LICENSE/README fetches to reference `n8.0.1` git tag

### `package.json`
- Updated `binary-release-tag` from `b6.1.1` to `b8.0.1` for both ffmpeg-static and ffprobe-static

### `README.md` and `packages/*/README.md`
- Updated version references from 6.1.1 to 8.0.1
- Updated binary source documentation to reflect BtbN for Linux x64/arm64
- Removed Windows 32-bit from supported platforms list (was already disabled)

## Testing

The download URLs have been verified to return valid responses:
- GyanD 8.0.1: ✓
- BtbN linux64/linuxarm64: ✓
- evermeet.cx 8.0.1 API: ✓
- osxexperts.net ffmpeg80arm.zip: ✓